### PR TITLE
Island chests

### DIFF
--- a/src/main/kotlin/io/illyria/skyblockx/command/island/IslandBaseCommand.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/command/island/IslandBaseCommand.kt
@@ -45,6 +45,7 @@ class IslandBaseCommand : SCommand(), CommandExecutor, TabCompleter {
         subCommands.add(CmdTop())
         subCommands.add(CmdCalc())
         subCommands.add(CmdValue())
+        subCommands.add(CmdChest())
         prefix = "/is"
 
         Globals.islandBaseCommand = this

--- a/src/main/kotlin/io/illyria/skyblockx/command/island/cmd/CmdChest.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/command/island/cmd/CmdChest.kt
@@ -1,0 +1,36 @@
+package io.illyria.skyblockx.command.island.cmd
+
+import io.illyria.skyblockx.command.CommandInfo
+import io.illyria.skyblockx.command.CommandRequirementsBuilder
+import io.illyria.skyblockx.command.SCommand
+import io.illyria.skyblockx.core.Permission
+import io.illyria.skyblockx.persist.Config
+import io.illyria.skyblockx.persist.Message
+import org.bukkit.Bukkit
+
+class CmdChest : SCommand() {
+
+    init {
+        aliases.add("chest")
+        aliases.add("inventory")
+        aliases.add("inv")
+
+
+        commandRequirements =
+            CommandRequirementsBuilder().withPermission(Permission.CHEST).asIslandMember(true).build()
+    }
+
+
+    override fun perform(info: CommandInfo) {
+        var inventory = info.island?.inventory
+//        if (inventory == null) {
+//            info.island?.inventory = Bukkit.createInventory(null, (Config.chestRows[1] ?: 3) * 9)
+//            inventory = info.island?.inventory
+//        }
+        info.player?.openInventory(inventory!!)
+    }
+
+    override fun getHelpInfo(): String {
+        return Message.commandChestHelp
+    }
+}

--- a/src/main/kotlin/io/illyria/skyblockx/command/island/cmd/CmdChest.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/command/island/cmd/CmdChest.kt
@@ -23,10 +23,6 @@ class CmdChest : SCommand() {
 
     override fun perform(info: CommandInfo) {
         var inventory = info.island?.inventory
-//        if (inventory == null) {
-//            info.island?.inventory = Bukkit.createInventory(null, (Config.chestRows[1] ?: 3) * 9)
-//            inventory = info.island?.inventory
-//        }
         info.player?.openInventory(inventory!!)
     }
 

--- a/src/main/kotlin/io/illyria/skyblockx/core/Island.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/core/Island.kt
@@ -37,6 +37,10 @@ data class Island(
 ) {
 
     var inventory = Bukkit.createInventory(null, (Config.chestRows[1] ?: 3) * 9)
+    get() {
+        if (field == null) field = Bukkit.createInventory(null, (Config.chestRows[1] ?: 3) * 9)
+        return field
+    }
 
     var beenToNether = false
     var netherFilePath = "nether-island.structure"

--- a/src/main/kotlin/io/illyria/skyblockx/core/Island.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/core/Island.kt
@@ -36,6 +36,8 @@ data class Island(
     var islandSize: Int
 ) {
 
+    var inventory = Bukkit.createInventory(null, (Config.chestRows[1] ?: 3) * 9)
+
     var beenToNether = false
     var netherFilePath = "nether-island.structure"
 

--- a/src/main/kotlin/io/illyria/skyblockx/core/Permission.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/core/Permission.kt
@@ -26,6 +26,7 @@ enum class Permission(val node: String, val description: String, val permissionD
     QUEST("quest", "opening the questing gui.", PermissionDefault.TRUE),
     OBSIDIANTOLAVA("obsidiantolava", "turn obsidian to lava with an empty bucket", PermissionDefault.FALSE),
     CALC("calc", "calculate your island's value", PermissionDefault.TRUE),
+    CHEST("chest", "open your island chest", PermissionDefault.TRUE),
     INFO("info", "gets island top information", PermissionDefault.TRUE),
     SE_SAVESTUCT("se.savestructure", "administrator skyblock edit save", PermissionDefault.OP),
     SE_PASTESTRUCT("se.pastestructure", "administrator skyblock edit paste", PermissionDefault.OP),

--- a/src/main/kotlin/io/illyria/skyblockx/persist/Config.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/persist/Config.kt
@@ -38,6 +38,8 @@ object Config {
         "eco take {player} 100"
     )
 
+    var chestRows = mapOf(1 to 3, 2 to 4, 3 to 5, 4 to 5, 5 to 6)
+
     var defaultMaxCoopPlayers = 3
 
     var defaultMaxIslandHomes = 3

--- a/src/main/kotlin/io/illyria/skyblockx/persist/Message.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/persist/Message.kt
@@ -56,6 +56,9 @@ object Message {
     var commandCreateAlreadyHaveAnIsland = "&7You already have an island, use /is delete to delete your island."
     var commandCreateSuccess = "&7Your island was successfully created."
 
+    var commandChestOpening = "&7Opening the island chest."
+    var commandChestHelp = "&7Open the island's virtual chest."
+
     var commandGoHelp = "&7Takes you to an island."
     var commandGoTeleporting = "&7Taking you to your island..."
 
@@ -218,6 +221,7 @@ object Message {
     var questProgressBarMessage = "&b&l{quest-name} {progress-bar} &b{percentage}%"
 
     var islandNetherTeleported = "&7You have been teleported to your nether island."
+
 
 
     var islandCreatedTitle = "&9SkyblockX"


### PR DESCRIPTION
Allows players to have a virtual, shared, island chest.
It has different levels, but only level 1 is active currently, as the upgrades system is not implemented yet.