### PR TITLE
Require 'skyblockx.reset' to reset the island.

### DIFF
--- a/src/main/kotlin/io/illyria/skyblockx/command/island/cmd/CmdReset.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/command/island/cmd/CmdReset.kt
@@ -4,6 +4,7 @@ import io.illyria.skyblockx.Globals
 import io.illyria.skyblockx.command.CommandInfo
 import io.illyria.skyblockx.command.CommandRequirementsBuilder
 import io.illyria.skyblockx.command.SCommand
+import io.illyria.skyblockx.core.Permission
 import io.illyria.skyblockx.persist.Message
 
 class CmdReset : SCommand() {
@@ -11,7 +12,7 @@ class CmdReset : SCommand() {
     init {
         aliases.add("reset")
 
-        commandRequirements = CommandRequirementsBuilder().asIslandMember(true).asLeader(true).build()
+        commandRequirements = CommandRequirementsBuilder().withPermission(Permission.RESET).asIslandMember(true).asLeader(true).build()
     }
 
     override fun perform(info: CommandInfo) {

--- a/src/main/kotlin/io/illyria/skyblockx/core/Permission.kt
+++ b/src/main/kotlin/io/illyria/skyblockx/core/Permission.kt
@@ -22,6 +22,7 @@ enum class Permission(val node: String, val description: String, val permissionD
     TELEPORT("teleport", "teleport to another island.", PermissionDefault.TRUE),
     LEAVE("leave", "leave your island.", PermissionDefault.TRUE),
     MENU("menu", "open the island menu.", PermissionDefault.TRUE),
+    RESET("reset", "reset your island.", PermissionDefault.TRUE),
     HOME("home", "manage island homes.", PermissionDefault.TRUE),
     ALLOWVISITOR("allowvisitor", "allow visitors on your island.", PermissionDefault.TRUE),
     QUEST("quest", "opening the questing gui.", PermissionDefault.TRUE),


### PR DESCRIPTION
Implement Feature requested in Issue #22 