### PR TITLE
Resolve issue with teleporting player from non-SBX world to SBX world after gliding

### DIFF
--- a/src/main/kotlin/net/savagelabs/skyblockx/core/Island.kt
+++ b/src/main/kotlin/net/savagelabs/skyblockx/core/Island.kt
@@ -461,6 +461,9 @@ data class Island(
      * This is built for checking bounds without checking the Y axis as it is not needed.
      */
     fun locationInIsland(v: Location): Boolean {
+        if (v.world!!.name != Config.skyblockWorldName && v.world!!.name != Config.skyblockWorldNameNether)
+            return false
+
         val x = v.x
         val z = v.z
         return x >= minLocation.x && x < maxLocation.x + 1 && z >= minLocation.z && z < maxLocation.z + 1

--- a/src/main/kotlin/net/savagelabs/skyblockx/listener/PlayerListener.kt
+++ b/src/main/kotlin/net/savagelabs/skyblockx/listener/PlayerListener.kt
@@ -299,7 +299,7 @@ class PlayerListener : Listener {
 
         val island = getIslandFromLocation(event.entity.location) ?: return
         val iPlayer = getIPlayer(event.entity as Player)
-        if (!island.allowVisitors && !island.hasCoopPlayer(iPlayer) && !island.getIslandMembers().contains(iPlayer)) {
+        if (!island.allowVisitors && !island.hasCoopPlayer(iPlayer) && !island.getIslandMembers().contains(iPlayer) && island.getOwnerIPlayer() != iPlayer) {
             if (iPlayer.hasIsland()) {
                 event.entity.teleport(island.islandGoPoint.getLocation())
             } else {


### PR DESCRIPTION
Discovered an issue on my server where when a player glides in the Nether, they would be teleported either some random island, or the overworld spawn.

After some digging, pretty sure this was being caused by the locationInIsland function not checking if the player is actually in either the SBX world, or the SBX Nether.

From there, I realized that it shouldn't have actually been teleporting the player to begin with as it was teleporting the player to their own island if they were to glide in the SBX world at all, even just inside their own boundaries. Added check to make sure that the player isn't the current owner of the island they are at, before teleporting them away.